### PR TITLE
Add a command-line interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/FawziAS/secret-santa.git"
 python = "^3.10"
 python-dotenv = "^0.19.2"
 twilio = "^7.5.1"
+pyfiglet = "^0.8.post1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"

--- a/secret_santa/util/arg_parser.py
+++ b/secret_santa/util/arg_parser.py
@@ -1,0 +1,95 @@
+import argparse
+from argparse import Namespace
+from typing import List
+
+from .logging import LoggingUtils
+
+
+class ArgParserUtils:
+    """A class aggregating all the arguments' parser utilities needed."""
+
+    class SmartFormatter(argparse.HelpFormatter):
+        """A super class of argparse.HelpFormatter solemnly for allowing new lines in the ``argparser``'s help"""
+
+        def _split_lines(self, text: str, width: int) -> List[str]:
+            """
+            Split lines and preserve line breaks in case ``text`` starts with ``|R`` (indicating raw).
+
+            Args:
+                text: The full string to be broken down according to the ``width`` given
+                    and whether it starts with ``|R``.
+                width: The width at which to wrap the text.
+
+            Returns:
+                A list of the broken down strings.
+
+            """
+            # If a line starts with R| (indicating Raw) preserve the line breaks and keep the indentation
+            if text.startswith("R|"):
+                import textwrap
+
+                lines = []
+                for line in text[2:].splitlines():
+                    if line.strip():
+                        lines.extend(textwrap.wrap(line, width))
+                return lines
+                # This is the RawTextHelpFormatter._split_lines
+            return argparse.HelpFormatter._split_lines(self, text, width)
+
+    @staticmethod
+    def parse_args() -> Namespace:
+        """
+        Parse the program's arguments.
+
+        Returns:
+            The parsed arguments in a namespace.
+
+        """
+        # TODO: Improve the argument parser by adding more arguments
+        parser = argparse.ArgumentParser(
+            formatter_class=ArgParserUtils.SmartFormatter,
+            description="Welcome to the Secret Santa Organizer, "
+            "in which each participant gets one other participant assigned, "
+            "to whom he should bring a gift!",
+            epilog="Merry Christmas! and have lots of fun :)",
+        )
+        parser.add_argument(
+            "--env-path",
+            default=None,
+            help="R|path to the .env file containing the required secrets\n"
+            'If omitted - will try to load the "{project_root}/.env".\n'
+            "--> Note: No error will be raised in case --env-path is not provided "
+            'and no "{project_root}/.env" exists.',
+        )
+        parser.add_argument(
+            "--participants-path",
+            default=None,
+            help='R|path to the "Secret Santa" participants JSON\n'
+            'If omitted - will try to load "{project_root}/participants.json".',
+        )
+        # TODO: Create a new logging level with the highest value possible and log the players arrangement
+        parser.add_argument(
+            "--show-arrangement",
+            default=False,
+            action="store_true",
+            help="R|show the final arrangement (participant -> receiver)\n"
+            "--> Note: The --show-arrangement is shown as logged INFO, which means "
+            "setting the logger any higher will not show the arrangements as expected.\n"
+            "--> Personal Request: Please keep it fun and use this only for development-testing purposes / "
+            "if you're a non-participating admin.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            default=False,
+            action="store_true",
+            help="run the program without actually sending the message",
+        )
+        parser.add_argument(
+            "-log",
+            "--logging-level",
+            default="info",
+            type=str.lower,
+            choices=LoggingUtils.logging_levels,
+            help='set the main logging level of the program loggers (Defaults to "info")',
+        )
+        return parser.parse_args()

--- a/secret_santa/util/logging.py
+++ b/secret_santa/util/logging.py
@@ -1,9 +1,24 @@
 import logging
-from typing import List
+from typing import Dict, List
 
 
 class LoggingUtils:
-    """A class aggregating all the logging utilities needed (mostly provided as static methods)."""
+    """
+    A class aggregating all the logging utilities needed (mostly provided as static methods).
+
+    Attributes:
+        logging_levels: Mapping of the program's supported logging levels to the actual logger levels' values.
+
+    """
+
+    logging_levels: Dict[str, int] = {
+        "critical": logging.CRITICAL,
+        "error": logging.ERROR,
+        "warn": logging.WARNING,
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
+    }
 
     class CustomLogFormatter(logging.Formatter):
         """A super class of ``logging.Formatter`` solemnly for custom log message formatting."""
@@ -51,8 +66,7 @@ class LoggingUtils:
         """
         # Retrieve the logger
         logger = logging.getLogger(name)
-        # Set the logger's level
-        logger.setLevel(logging.DEBUG)
+        # The logger's main logging level will be set by the root logger
 
         # If no handlers has been passed, set handlers to be an empty list
         if not handlers:


### PR DESCRIPTION
This PR includes:
* Add `ArgParserUtils`
  * Add an `argparser` to enable adding a command-line interface.
  * Enable editing and running the program from the command line without changing the code (needed attributes and arguments are passed as arguments to the program, e.g. `python secret_santa --dry-run -log debug --participants-path ./additional_files/participants.json --show-arrangement`).
    * All supported arguments could be found by running `python secret_santa --help`.
* Refactor `secret_santa` module to accommodate the changes.