### PR TITLE
Test on `Python 3.11` and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/FawziAS/secret-santa.git"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-python-dotenv = "^0.20.0"
-twilio = "^7.5.1"
+python-dotenv = "^0.21.0"
+twilio = "^7.15.4"
 pyfiglet = "^0.8.post1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR updates the project's, and the testing workflow's dependencies, while also adding `Python 3.11` testing.