### PR TITLE
Enable `ruff` and update dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Upgrade pip
@@ -21,9 +21,9 @@ jobs:
         run: python -m pip install poetry
       - name: Install dependencies
         run: poetry install
-      - name: Check isort
-        run: poetry run task isort_check
-      - name: Check black
-        run: poetry run task black_check
-      - name: Check mypy
+      - name: Check format
+        run: poetry run task format_check
+      - name: Lint code
+        run: poetry run task ruff_lint --output-format=github
+      - name: Check types
         run: poetry run task mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pyfiglet = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
-taskipy = "^1.12.0"
+taskipy = "^1.12.2"
 pytest-lazy-fixture = "^0.6.3"
 pytest-mock = "^3.11.1"
 mypy = "^1.5.1"
@@ -69,12 +69,34 @@ sources_only = "secret_santa/"
 tests_only = "tests/"
 
 [tool.taskipy.tasks]
-format_check = { cmd = "task format --check", use_vars = true, help = "run ruff format on sources and tests in check mode (no writing back)." }
-ruff_lint = { cmd = "ruff check {all_paths}", use_vars = true, help = "run ruff linter on sources and tests." }
-ruff_lint_fix = { cmd = "task ruff_lint --fix", use_vars = true, help = "[changes code] run ruff linter and fix fixable issues on sources and tests." }
-mypy = { cmd = "mypy {all_paths}", use_vars = true, help = "run mypy on sources." }
+pre_format_check = { cmd = "echo 'Running the \"format_check\" task...'" }
+format_check = { cmd = "ruff format {all_paths} --check", use_vars = true, help = "run ruff format on sources and tests in check mode." }
+post_format_check = { cmd = "echo 'Done running the \"format_check\" task!'" }
 
-format = { cmd = "ruff format {all_paths}", use_vars = true, help = "[changes code] run ruff format on sources and tests." }
-lint = { cmd = "task format_check && task ruff_lint && task mypy", help = "check code formatting and rules violations." }
-fix = { cmd = "task format && task ruff_lint_fix", help = "[changes code] reformat code and fix fixable linting issues." }
+pre_ruff_lint = { cmd = "echo 'Running the \"ruff_lint\" task...'" }
+ruff_lint = { cmd = "ruff check {all_paths}", use_vars = true, help = "run ruff linter on sources and tests." }
+post_ruff_lint = { cmd = "echo 'Done running the \"ruff_lint\" task!'" }
+
+pre_ruff_lint_fix = { cmd = "echo 'Running the \"ruff_lint_fix\" task...'" }
+ruff_lint_fix = { cmd = "ruff check {all_paths} --fix", use_vars = true, help = "[changes code] run ruff linter and fix fixable issues on sources and tests." }
+post_ruff_lint_fix = { cmd = "echo 'Done running the \"ruff_lint_fix\" task!'" }
+
+pre_mypy = { cmd = "echo 'Running the \"mypy\" task...'" }
+mypy = { cmd = "mypy {all_paths}", use_vars = true, help = "run mypy on sources and tests." }
+post_mypy = { cmd = "echo 'Done running the \"mypy\" task!'" }
+
+pre_test = { cmd = "echo 'Running the \"test\" task...'" }
 test = { cmd = "pytest -v {tests_only}", use_vars = true, help = "run all tests." }
+post_test = { cmd = "echo 'Done running the \"test\" task!'" }
+
+pre_format = { cmd = "echo 'Running the \"format\" task...'" }
+format = { cmd = "ruff format {all_paths}", use_vars = true, help = "[changes code] run ruff format on sources and tests." }
+post_format = { cmd = "echo 'Done running the \"format\" task!'" }
+
+pre_lint = { cmd = "echo 'Linting the whole codebase...'" }
+lint = { cmd = "task format_check && task ruff_lint && task mypy", help = "check code formatting and rules violations." }
+post_lint = { cmd = "echo 'Done linting the whole codebase!'" }
+
+pre_fix = { cmd = "echo 'Formating code and fixing fixable issues accross the whole codebase...'" }
+fix = { cmd = "task format && task ruff_lint_fix", help = "[changes code] reformat code and fix fixable linting issues." }
+post_fix = { cmd = "echo 'Done formating code and fixing fixable issues accross the whole codebase!'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,37 +5,44 @@ description = "A Secret Santa game which randomly assigns and notifies people to
 license = "Unlicense"
 authors = ["Fawzi Abo Shkara <fawzi.aboshkara@gmail.com>"]
 readme = "README.md"
-homepage = "https://github.com/FawziAS/secret-santa"
-repository = "https://github.com/FawziAS/secret-santa.git"
+homepage = "https://github.com/faboshka/secret-santa"
+repository = "https://github.com/faboshka/secret-santa.git"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = "^3.12"
 python-dotenv = "^1.0.0"
-twilio = "^8.7.0"
-pyfiglet = "^0.8.post1"
+twilio = "^8.11.0"
+pyfiglet = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
-black = "^23.7.0"
-isort = "^5.12.0"
 taskipy = "^1.12.0"
 pytest-lazy-fixture = "^0.6.3"
 pytest-mock = "^3.11.1"
 mypy = "^1.5.1"
 types-pytest-lazy-fixture = "^0.6.3.4"
+ruff = "^0.1.11"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black] # The black formatter config
-line-length = 100
+[tool.ruff]
+line-length = 120
 
-[tool.isort] # isort config
-profile = "black"
-line_length = 100
-src_paths = ["secret_santa", "tests"]
-skip_gitignore = true
+[tool.ruff.lint]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 pretty = true
@@ -62,12 +69,12 @@ sources_only = "secret_santa/"
 tests_only = "tests/"
 
 [tool.taskipy.tasks]
-test = { cmd = "pytest -v {tests_only}", use_vars = true, help = "run all tests." }
-isort = { cmd = "isort {all_paths}", use_vars = true, help = "run isort on sources and tests." }
-black = { cmd = "black {all_paths}", use_vars = true, help = "run black on sources and tests." }
+format_check = { cmd = "task format --check", use_vars = true, help = "run ruff format on sources and tests in check mode (no writing back)." }
+ruff_lint = { cmd = "ruff check {all_paths}", use_vars = true, help = "run ruff linter on sources and tests." }
+ruff_lint_fix = { cmd = "task ruff_lint --fix", use_vars = true, help = "[changes code] run ruff linter and fix fixable issues on sources and tests." }
 mypy = { cmd = "mypy {all_paths}", use_vars = true, help = "run mypy on sources." }
-format = { cmd = "task isort && task black", help = "reformat code" }
 
-isort_check = { cmd = "task isort --check-only", help = "run task isort in check mode (no writing back)." }
-black_check = { cmd = "task black --check", help = "run task black in check mode (no writing back)." }
-lint = { cmd = "task isort_check && task black_check && task mypy", help = "check code formatting." }
+format = { cmd = "ruff format {all_paths}", use_vars = true, help = "[changes code] run ruff format on sources and tests." }
+lint = { cmd = "task format_check && task ruff_lint && task mypy", help = "check code formatting and rules violations." }
+fix = { cmd = "task format && task ruff_lint_fix", help = "[changes code] reformat code and fix fixable linting issues." }
+test = { cmd = "pytest -v {tests_only}", use_vars = true, help = "run all tests." }

--- a/secret_santa/secret_santa_module.py
+++ b/secret_santa/secret_santa_module.py
@@ -11,9 +11,9 @@ from typing import Optional
 import pyfiglet
 from dotenv import load_dotenv
 
-from secret_santa.twilio_messaging_service import TwilioMessagingService
 from secret_santa.const import TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_NUMBER
 from secret_santa.model.participant import Participant
+from secret_santa.twilio_messaging_service import TwilioMessagingService
 from secret_santa.util import arg_parser, file, misc, path
 from secret_santa.util import logging as logging_util
 

--- a/secret_santa/secret_santa_module.py
+++ b/secret_santa/secret_santa_module.py
@@ -11,12 +11,11 @@ from typing import Optional
 import pyfiglet
 from dotenv import load_dotenv
 
+from secret_santa.twilio_messaging_service import TwilioMessagingService
 from secret_santa.const import TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_NUMBER
 from secret_santa.model.participant import Participant
-from secret_santa.twilio_messaging_service import TwilioMessagingService
-from secret_santa.util import arg_parser, file
+from secret_santa.util import arg_parser, file, misc, path
 from secret_santa.util import logging as logging_util
-from secret_santa.util import misc, path
 
 # Set up the main logger
 logger = logging_util.get_logger("main")
@@ -100,9 +99,7 @@ class SecretSanta:
             f"Current number of participants: {len(participants_dict_list)}"
         )
         # Load the participants' dicts to a list of ``Participant``s
-        participants = [
-            Participant(**participant_dict) for participant_dict in participants_dict_list
-        ]
+        participants = [Participant(**participant_dict) for participant_dict in participants_dict_list]
         for participant in participants:
             self.logger.debug(f"Loaded: {participant}")
         return participants
@@ -137,11 +134,7 @@ class SecretSanta:
             The name of the participant as it'll appear in the message to be sent.
 
         """
-        return (
-            participant.nickname
-            if participant.nickname
-            else participant.full_name.strip().split()[0]
-        )
+        return participant.nickname if participant.nickname else participant.full_name.strip().split()[0]
 
     @staticmethod
     def get_secret_santa_message(participant: Participant, recipient: Participant) -> str:
@@ -161,9 +154,7 @@ class SecretSanta:
         # Recipient name to use
         recipient_msg_name = SecretSanta.get_participant_message_name(recipient)
         # Construct message
-        message_body = (
-            f"Hello {participant_msg_name},\n" f"You'll be {recipient_msg_name}'s Secret Santa!"
-        )
+        message_body = f"Hello {participant_msg_name},\n" f"You'll be {recipient_msg_name}'s Secret Santa!"
         return message_body
 
     def run(self) -> int:
@@ -228,9 +219,7 @@ def load_env(dotenv_path: Optional[PathLike] = None, override_system: bool = Fal
     logger.debug("Asserting Twilio configuration has been provided")
     required_env_vars = [TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_NUMBER]
     if not all([os.getenv(env) for env in required_env_vars]):
-        raise SystemExit(
-            f"One or more of the environment variables needed ({required_env_vars}) has not been passed."
-        )
+        raise SystemExit(f"One or more of the environment variables needed ({required_env_vars}) has not been passed.")
     logger.info("Environment loaded successfully")
 
 

--- a/secret_santa/util/misc.py
+++ b/secret_santa/util/misc.py
@@ -26,8 +26,7 @@ def is_derangement(list_a: list[T], list_b: list[T]) -> bool:
     )
     # Assert the two lists are of the same length
     assert len(list_a) == len(list_b), (
-        f"The two lists must be of the same size to qualify for a derangement check: "
-        f"{len(list_a)} != {len(list_b)}"
+        f"The two lists must be of the same size to qualify for a derangement check: " f"{len(list_a)} != {len(list_b)}"
     )
     # Assert the two lists contain items of the same type
     assert not any([True if type(x) != type(y) else False for x, y in zip(list_a, list_b)]), (

--- a/tests/test_secret_santa.py
+++ b/tests/test_secret_santa.py
@@ -229,7 +229,7 @@ def test_module_main(
     else:
         assert (
             create_message_mock.call_count == 3
-        ), f"The `create` method of the Twilio API was not called the number of times expected 3."
+        ), "The `create` method of the Twilio API was not called the number of times expected 3."
 
 
 @pytest.mark.parametrize(
@@ -257,19 +257,14 @@ def test_init(
         dry_run=dry_run,
     )
 
-    assert (
-        secret_santa_obj.logger.name == "SecretSanta"
-    ), "The logger was not initialized with the proper name."
+    assert secret_santa_obj.logger.name == "SecretSanta", "The logger was not initialized with the proper name."
     assert (
         secret_santa_obj.dry_run == dry_run
     ), 'The value initialized in the object for "dry_run" does not match the expected value.'
     assert secret_santa_obj.show_arrangement == show_arrangement, (
-        'The value initialized in the object for "show_arrangement" does not match the '
-        "expected value."
+        'The value initialized in the object for "show_arrangement" does not match the ' "expected value."
     )
-    assert (
-        secret_santa_obj.messaging_client is not None
-    ), "The messaging service was not initialized as expected."
+    assert secret_santa_obj.messaging_client is not None, "The messaging service was not initialized as expected."
 
 
 def test_init_defaults(
@@ -294,9 +289,7 @@ def test_init_defaults(
     secret_santa_obj = SecretSanta(dry_run=True)
 
     path_join_mock.assert_called()
-    load_participants_mock.assert_called_once_with(
-        participants_json_path=project_root_directory / "participants.json"
-    )
+    load_participants_mock.assert_called_once_with(participants_json_path=project_root_directory / "participants.json")
     assert (
         secret_santa_obj.show_arrangement is False
     ), "The default value for show_arrangement does not match the expected value."
@@ -307,9 +300,7 @@ def test_load_participants(
     test_participants_file_path: Path,
     participants_in_participants_file: list[Participant],
 ) -> None:
-    loaded_participants = default_secret_santa_instance.load_participants(
-        test_participants_file_path
-    )
+    loaded_participants = default_secret_santa_instance.load_participants(test_participants_file_path)
 
     assert (
         loaded_participants == participants_in_participants_file
@@ -332,9 +323,7 @@ def test_get_participant_message_name(
 ) -> None:
     message_name = default_secret_santa_instance.get_participant_message_name(participant)
 
-    assert (
-        message_name == expected_message_name
-    ), "The message name returned does not match the expected message name."
+    assert message_name == expected_message_name, "The message name returned does not match the expected message name."
 
 
 @pytest.mark.parametrize("execution_number", range(9))
@@ -372,9 +361,7 @@ def test_secret_santa_message(
     expected_message: str,
 ) -> None:
     message = default_secret_santa_instance.get_secret_santa_message(participant, recipient)
-    assert (
-        message == expected_message
-    ), 'The "Secret Santa" message generated does not match the expected message.'
+    assert message == expected_message, 'The "Secret Santa" message generated does not match the expected message.'
 
 
 @pytest.mark.parametrize("dry_run", [False, True])

--- a/tests/test_twilio_messaging_service.py
+++ b/tests/test_twilio_messaging_service.py
@@ -69,9 +69,8 @@ def test_invalid_config(
         )
     with pytest.raises(AssertionError) as exception_info:
         TwilioMessagingService()
-    assert (
-        "Required environment variables TWILIO_ACCOUNT_SID or TWILIO_AUTH_TOKEN or TWILIO_NUMBER missing."
-        in str(exception_info.value)
+    assert "Required environment variables TWILIO_ACCOUNT_SID or TWILIO_AUTH_TOKEN or TWILIO_NUMBER missing." in str(
+        exception_info.value
     ), "The assertion raised does not match the assertion expected."
 
 
@@ -108,9 +107,8 @@ def test_invalid_twilio_messaging_service_alphanumeric_id(
 ) -> None:
     with pytest.raises(AssertionError) as exception_info:
         twilio_messaging_service_builder(alphanumeric_id)
-    assert (
-        "The alphanumeric sender Id can only contain up to 11 characters from the following categories:"
-        in str(exception_info.value)
+    assert "The alphanumeric sender Id can only contain up to 11 characters from the following categories:" in str(
+        exception_info.value
     ), "The assertion raised does not match the assertion expected."
 
 

--- a/tests/util/test_arg_parser.py
+++ b/tests/util/test_arg_parser.py
@@ -65,6 +65,4 @@ def test_arg_parser(
 
     resulting_namespace = update_namespace_with_diff(default_namespace, namespace_diff)
     namespace: Namespace = secret_santa_arg_parser.parse_args(input_)
-    assert (
-        namespace == resulting_namespace
-    ), "The namespace constructed does not match the expected namespace."
+    assert namespace == resulting_namespace, "The namespace constructed does not match the expected namespace."

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -17,12 +17,9 @@ def tests_temp_directory(tests_directory: Path) -> Path:
 
 
 def test_read_file(test_file_path: Path) -> None:
-    file_text = (
-        f"This is a simple text file which will be used to test the read file function.\n"
-        f"Let's hope it'll work :)"
-    )
+    txt = "This is a simple text file which will be used to test the read file function.\n" "Let's hope it'll work :)"
     read_file: str = file.read_file(file_name=test_file_path)
-    assert read_file == file_text, "The file contents read does not match the expected content."
+    assert read_file == txt, "The file contents read does not match the expected content."
 
 
 def test_create_file(tests_temp_directory: Path) -> None:
@@ -30,9 +27,7 @@ def test_create_file(tests_temp_directory: Path) -> None:
     new_file_content: str = "This is a simple text file creation to test create_file()"
     try:
         file.create_file(full_file_name=new_file_path, content=new_file_content)
-        assert os.path.exists(
-            new_file_path
-        ), f"A new txt file ({new_file_path}) should've been created"
+        assert os.path.exists(new_file_path), f"A new txt file ({new_file_path}) should've been created"
         read_content: str = file.read_file(new_file_path)
         assert (
             read_content == new_file_content

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -63,7 +63,6 @@ def test_is_derangement_fails_on_lists_of_different_length(list1: list[T], list2
 def test_is_derangement_fails_on_lists_of_different_types(list1: list[T], list2: list[T]) -> None:
     with pytest.raises(AssertionError) as exception_info:
         misc.is_derangement(list1, list2)
-    assert (
-        "The two lists' elements must be of the same type to qualify for a derangement check"
-        in str(exception_info.value)
+    assert "The two lists' elements must be of the same type to qualify for a derangement check" in str(
+        exception_info.value
     ), "The assertion raised does not match the assertion expected."


### PR DESCRIPTION
This PR enables `ruff` (linter and formatter), which in its place replaces `black` and `isort` for this project's usage.  
As a result of `ruff`'s addition, `black` and `isort` have been removed, and the `taskipy` tasks and GitHub actions have been updated accordingly.

Additionally, this PR updates the dependencies (including a couple of major ones) of the code.

---

### Side Effects:

* The supported Python version is now `3.12`
* The Python code line length has been updated to 120 (instead of 100)

---

### Possible Followups:

* #28 
* #19 