### PR TITLE
Improve the testing task and workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install poetry
         run: python -m pip install poetry
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --only main,dev
       - name: Check format
         run: poetry run task format_check
       - name: Lint code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install poetry
         run: python -m pip install poetry
       - name: Install dependencies
-        run: poetry install --only main,dev
+        run: poetry install
       - name: Check format
         run: poetry run task format_check
       - name: Lint code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install poetry
         run: python -m pip install poetry
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --only main,test
       - name: Run tests
-        run: poetry run pytest tests --junitxml=junit.xml
+        run: poetry run pytest tests --junitxml=junit.xml -n auto
       - name: Test reporter
         uses: dorny/test-reporter@v1
         if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Install poetry
         run: python -m pip install poetry
       - name: Install dependencies
-        run: poetry install --only main,test
+        run: |
+          poetry add pytest-github-actions-annotate-failures@latest --group=test
+          poetry install --only main,test
       - name: Run tests
         run: poetry run pytest tests --junitxml=junit.xml -n auto
       - name: Test reporter
@@ -35,3 +37,5 @@ jobs:
           path: junit.xml
           reporter: java-junit
           output-to: step-summary
+          only-summary: true
+          max-annotations: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Run tests
         run: poetry run pytest tests --junitxml=junit.xml -n auto
       - name: Test reporter
-        uses: dorny/test-reporter@v1
+        uses: phoenix-actions/test-reporting@v12
         if: success() || failure()
         with:
           name: Secret Santa tests on ${{ matrix.os }} (Python ${{ matrix.python-version }}) Report
           path: junit.xml
           reporter: java-junit
+          output-to: step-summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ mypy = { cmd = "mypy {all_paths}", use_vars = true, help = "run mypy on sources 
 post_mypy = { cmd = "echo 'Done running the \"mypy\" task!'" }
 
 pre_test = { cmd = "echo 'Running the \"test\" task...'" }
-test = { cmd = "pytest -v {tests_only}", use_vars = true, help = "run all tests." }
+test = { cmd = "pytest -v {tests_only} -n auto", use_vars = true, help = "run all tests." }
 post_test = { cmd = "echo 'Done running the \"test\" task!'" }
 
 pre_format = { cmd = "echo 'Running the \"format\" task...'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,16 @@ twilio = "^8.11.0"
 pyfiglet = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4.0"
 taskipy = "^1.12.2"
-pytest-lazy-fixture = "^0.6.3"
-pytest-mock = "^3.11.1"
 mypy = "^1.5.1"
-types-pytest-lazy-fixture = "^0.6.3.4"
 ruff = "^0.1.11"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^7.4.4"
+pytest-lazy-fixture = "^0.6.3"
+pytest-mock = "^3.12.0"
+types-pytest-lazy-fixture = "^0.6.3.4"
+pytest-xdist = "^3.5.0"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ pyfiglet = "^1.0.2"
 taskipy = "^1.12.2"
 mypy = "^1.5.1"
 ruff = "^0.1.11"
+types-pytest-lazy-fixture = "^0.6.3.4"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.4"
 pytest-lazy-fixture = "^0.6.3"
 pytest-mock = "^3.12.0"
-types-pytest-lazy-fixture = "^0.6.3.4"
 pytest-xdist = "^3.5.0"
 
 [build-system]

--- a/tests/test_secret_santa.py
+++ b/tests/test_secret_santa.py
@@ -21,12 +21,14 @@ from secret_santa.util import misc
 # TODO: Remove in refactor and get rid of env load as this has some unintended side effects
 @pytest.fixture(autouse=True)
 def clear_environment(mocker: MockerFixture) -> Iterator:
+    def is_github_environment_variable(name: str) -> bool:
+        return any(name.startswith(gh_env_prefix) for gh_env_prefix in ["GITHUB_", "RUNNER_"])
+
     # This is essentially a pretest to clear the environment, as all tests run in the same session
     # with environment variables loaded from another tests.
     # Note:
     #   Until this is taken care of properly - the GitHub actions environment variables should not be cleared if exists.
-    is_github_env_var = lambda key: any(key.startswith(gh_env_prefix) for gh_env_prefix in ["GITHUB_", "RUNNER_"])
-    github_env_variables = {key: val for key, val in os.environ.items() if is_github_env_var(key)}
+    github_env_variables = {key: val for key, val in os.environ.items() if is_github_environment_variable(key)}
     mocker.patch.dict(os.environ, {**github_env_variables}, clear=True)
     yield
 
@@ -163,7 +165,6 @@ def test_env_file_value_override_existing(
     system_values: list[tuple[str, str]],
     expected: list[tuple[str, str]],
 ) -> None:
-    assert False
     for env_key, env_value in system_values:
         monkeypatch.setenv(env_key, env_value)
     load_env(dotenv_path=test_env_file_path, override_system=override_system)

--- a/tests/test_secret_santa.py
+++ b/tests/test_secret_santa.py
@@ -18,11 +18,16 @@ from secret_santa.secret_santa_module import SecretSanta, load_env
 from secret_santa.util import misc
 
 
+# TODO: Remove in refactor and get rid of env load as this has some unintended side effects
 @pytest.fixture(autouse=True)
 def clear_environment(mocker: MockerFixture) -> Iterator:
     # This is essentially a pretest to clear the environment, as all tests run in the same session
     # with environment variables loaded from another tests.
-    mocker.patch.dict(os.environ, {}, clear=True)
+    # Note:
+    #   Until this is taken care of properly - the GitHub actions environment variables should not be cleared if exists.
+    is_github_env_var = lambda key: any(key.startswith(gh_env_prefix) for gh_env_prefix in ["GITHUB_", "RUNNER_"])
+    github_env_variables = {key: val for key, val in os.environ.items() if is_github_env_var(key)}
+    mocker.patch.dict(os.environ, {**github_env_variables}, clear=True)
     yield
 
 
@@ -158,6 +163,7 @@ def test_env_file_value_override_existing(
     system_values: list[tuple[str, str]],
     expected: list[tuple[str, str]],
 ) -> None:
+    assert False
     for env_key, env_value in system_values:
         monkeypatch.setenv(env_key, env_value)
     load_env(dotenv_path=test_env_file_path, override_system=override_system)


### PR DESCRIPTION
This PR adds a couple of improvements to the testing task and workflow:

* Separate `test` dependencies from the dev dependencies
  * This way there'd be less packages to install during the `poetry install` command in the testing workflow
  * This doesn't help the lint flow as we're usually linting the whole codebase **including the tests**
* Parallelize the tests running across all cores
  * This does improve the execution time a bit but the improvement is negligible as the whole test suite takes ~3 seconds to test
  * Adding this because it is cool 😃 
* Change the test reporter used to a fork of dorney's test reporter
  * Replaced in order to allow for step-summary instead of an additional check (cleaner look)
* Add GitHub annotations to the failed tests using a plugin to be installed on the GitHub testing workflow run
* Have the summary be only a summary (without listing the issues and without annotations) as there is a different plugin for it now